### PR TITLE
Code decoupling between features and compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,9 @@
 /ssh.configuration
 /findbugsReport.html
 /lib
-/.settings
-/.project
-/.classpath
+**/*.classpath
+**/*.project
+**/*.settings
 /.factorypath
 /lombok.iml
 /.idea

--- a/src/core/lombok/experimental/core/LombokCompiler.java
+++ b/src/core/lombok/experimental/core/LombokCompiler.java
@@ -1,0 +1,113 @@
+package lombok.experimental.core;
+
+import java.util.List;
+
+import lombok.experimental.core.LombokFactory.Message;
+import lombok.experimental.core.descriptor.AnnotationDescriptor;
+import lombok.experimental.core.descriptor.ClassDescriptor;
+import lombok.experimental.core.descriptor.ConstructorDescriptor;
+import lombok.experimental.core.descriptor.FieldDescriptor;
+import lombok.experimental.core.descriptor.GenericDescriptor;
+import lombok.experimental.core.descriptor.GenericTypeDescriptor;
+import lombok.experimental.core.descriptor.InterfaceDescriptor;
+import lombok.experimental.core.descriptor.MethodArgumentDescriptor;
+import lombok.experimental.core.descriptor.MethodDescriptor;
+import lombok.experimental.core.descriptor.MethodExceptionDescriptor;
+import lombok.experimental.core.descriptor.PackageDescriptor;
+
+/**
+ * This interface is required to translate internal descriptor objects into real
+ * code or whatever is needed. Supposed to return only messages which will be
+ * displayed or dumped or whatever. Main purpose of this interface is to
+ * decouple high-level business logic from low-level compilers.
+ */
+// TODO: some long reading is here
+/*
+ * It looks odd to have such amount of methods in a single class, but this would
+ * allow testing it properly. Compiler may be filled with functionality on
+ * demand. And once it is implemented and fully covered with tests it may be
+ * re-used everywhere. Thus no need to have similar code for handling different
+ * annotations. Right now handler classes for Eclipse compiler and for Java
+ * compiler have same business logic inside with adding this as an interface, it
+ * will be located in single place. In theory compiler implementation may be
+ * replaced with anything like JavasciptCompiler, PythonCompiler, whatever...
+ * This is slightly limited by hierarchy of descriptors, but it can be fixed in
+ * the way to be like a real tree structure. After that it may be used for
+ * generating everything (like sql's etc.)
+ */
+// TODO: right now compiler does return only messages, but most likely it should
+// return smth else.
+// i'm pretty sure compilers may dump all messages within. and throw errors when
+// everything is pretty bad
+// this would allow to pass some results back to be re-used or stored or
+// whatever.
+public interface LombokCompiler {
+	
+	// TODO: method names are subject of discussion
+	
+	List<Message> add(AnnotationDescriptor descriptor, boolean generate);
+	
+	List<Message> add(ClassDescriptor descriptor, boolean generate);
+	
+	List<Message> add(ConstructorDescriptor descriptor, boolean generate);
+	
+	List<Message> add(FieldDescriptor descriptor, boolean generate);
+	
+	List<Message> add(GenericDescriptor descriptor, boolean generate);
+	
+	List<Message> add(GenericTypeDescriptor descriptor, boolean generate);
+	
+	List<Message> add(InterfaceDescriptor descriptor, boolean generate);
+	
+	List<Message> add(MethodArgumentDescriptor descriptor, boolean generate);
+	
+	List<Message> add(MethodDescriptor descriptor, boolean generate);
+	
+	List<Message> add(MethodExceptionDescriptor descriptor, boolean generate);
+	
+	List<Message> add(PackageDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(AnnotationDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(ClassDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(ConstructorDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(FieldDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(GenericDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(GenericTypeDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(InterfaceDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(MethodArgumentDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(MethodDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(MethodExceptionDescriptor descriptor, boolean generate);
+	
+	List<Message> modify(PackageDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(AnnotationDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(ClassDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(ConstructorDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(FieldDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(GenericDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(GenericTypeDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(InterfaceDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(MethodArgumentDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(MethodDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(MethodExceptionDescriptor descriptor, boolean generate);
+	
+	List<Message> remove(PackageDescriptor descriptor, boolean generate);
+}

--- a/src/core/lombok/experimental/core/LombokDescriptorFactory.java
+++ b/src/core/lombok/experimental/core/LombokDescriptorFactory.java
@@ -1,0 +1,37 @@
+package lombok.experimental.core;
+
+import java.util.List;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.experimental.SuperBuilder;
+import lombok.experimental.core.descriptor.ClassDescriptor;
+import lombok.experimental.core.descriptor.MemberType;
+import lombok.experimental.core.descriptor.Modifier;
+
+public interface LombokDescriptorFactory {
+	
+	@EqualsAndHashCode @Getter @SuperBuilder public static class Configuration {
+		@Singular private List<MemberType> memberTypes;
+		@Singular private List<Modifier> modifiers;
+		private Configuration members;
+		// ^^ classes, interfaces, methods, fields (declared or all depends on
+		// modifiers and member types)
+		
+		private Configuration parents;
+		// ^^ configuration for diving into parents (implements and extends)
+		
+		private int depth;
+		// controls depth for parents
+	}
+	
+	/**
+	 * Describe class with provided configuration
+	 * 
+	 * @param type
+	 * @param configuration
+	 * @return
+	 */
+	ClassDescriptor get(Class<?> type, Configuration configuration);
+}

--- a/src/core/lombok/experimental/core/LombokFactory.java
+++ b/src/core/lombok/experimental/core/LombokFactory.java
@@ -1,0 +1,51 @@
+package lombok.experimental.core;
+
+import java.awt.TrayIcon.MessageType;
+import java.util.List;
+
+import lombok.Data;
+import lombok.experimental.core.descriptor.Descriptor;
+
+public interface LombokFactory {
+	
+	public enum Action {
+		ADD {
+			@Override public List<Message> apply(LombokCompiler compiler, Descriptor descriptor, boolean generate) {
+				return descriptor.add(compiler, generate);
+			}
+		},
+		MODIFY {
+			@Override public List<Message> apply(LombokCompiler compiler, Descriptor descriptor, boolean generate) {
+				return descriptor.modify(compiler, generate);
+			}
+		},
+		REMOVE {
+			@Override public List<Message> apply(LombokCompiler compiler, Descriptor descriptor, boolean generate) {
+				return descriptor.remove(compiler, generate);
+			}
+		};
+		
+		public abstract List<Message> apply(LombokCompiler compiler, Descriptor descriptor, boolean generate);
+	}
+	
+	@Data public static class Message {
+		private MessageType type;
+		private String value;
+		
+		public boolean hasType(MessageType expected) {
+			return type == expected;
+		}
+	}
+	
+	public enum MessageLevel {
+		INFO, WARN, ERROR;
+	}
+	
+	/**
+	 * Used to collect generation messages and if enabled generate vanilla java
+	 * for the provided class
+	 * 
+	 * @param type
+	 */
+	List<Message> generate(Class<?> type, boolean generate);
+}

--- a/src/core/lombok/experimental/core/LombokPriorityFactory.java
+++ b/src/core/lombok/experimental/core/LombokPriorityFactory.java
@@ -1,0 +1,9 @@
+package lombok.experimental.core;
+
+import java.util.Comparator;
+
+import lombok.experimental.core.descriptor.AnnotationDescriptor;
+
+public interface LombokPriorityFactory extends Comparator<AnnotationDescriptor> {
+	int getPriority(AnnotationDescriptor descriptor);
+}

--- a/src/core/lombok/experimental/core/descriptor/AnnotationDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/AnnotationDescriptor.java
@@ -1,0 +1,65 @@
+package lombok.experimental.core.descriptor;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import jdk.nashorn.internal.objects.annotations.Setter;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data @EqualsAndHashCode(callSuper = true) public class AnnotationDescriptor extends MemberDescriptor {
+	private List<AnnotationDescriptor> annotations;
+	private List<Modifier> modifiers;
+	private Descriptor target; // type, method, method argument, field
+	private String name;
+	
+	private Annotation reference;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.ANNOTATION;
+	}
+	
+	@Override public MemberType getMemberType() {
+		return MemberType.ANNOTATION;
+	}
+	
+	/**
+	 * Checks if reference annotation matches provided one
+	 * 
+	 * @param type
+	 * @return
+	 */
+	public boolean hasAnnotation(Class<?> type) {
+		if (reference == null) {
+			return false;
+		}
+		return reference.annotationType() == type;
+	}
+	
+	/**
+	 * Should return true if annotation is lombok one
+	 * 
+	 * @return
+	 */
+	public boolean isLombok() {
+		// TODO: implement filtering by lombok annotations
+		// most suitable way - annotate each lombok annotation with some generic
+		// one
+		
+		return hasAnnotation(Setter.class);
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/descriptor/ClassDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/ClassDescriptor.java
@@ -1,0 +1,39 @@
+package lombok.experimental.core.descriptor;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data @EqualsAndHashCode(callSuper = true) public class ClassDescriptor extends MemberDescriptor {
+	private List<InterfaceDescriptor> implemented;
+	private List<MemberDescriptor> members;
+	private PackageDescriptor packaged;
+	private ClassDescriptor extended;
+	private String name;
+	
+	private Class<?> reference;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.CLASS;
+	}
+	
+	@Override public MemberType getMemberType() {
+		return MemberType.CLASS;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+	
+}

--- a/src/core/lombok/experimental/core/descriptor/ConstructorDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/ConstructorDescriptor.java
@@ -1,0 +1,38 @@
+package lombok.experimental.core.descriptor;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data @EqualsAndHashCode(callSuper = true) public class ConstructorDescriptor extends MemberDescriptor {
+	private MethodExceptionDescriptor[] exceptions;
+	private MethodArgumentDescriptor[] arguments;
+	private BiConsumer<Object, Object[]> handler;
+	
+	private Constructor<?> reference;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.CONSTRUCTOR;
+	}
+	
+	@Override public MemberType getMemberType() {
+		return MemberType.CONSTRUCTOR;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/descriptor/Descriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/Descriptor.java
@@ -1,0 +1,17 @@
+package lombok.experimental.core.descriptor;
+
+import java.util.List;
+
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+public interface Descriptor {
+	
+	List<Message> add(LombokCompiler compiler, boolean generate);
+	
+	DescriptorType getDescriptorType();
+	
+	List<Message> modify(LombokCompiler compiler, boolean generate);
+	
+	List<Message> remove(LombokCompiler compiler, boolean generate);
+}

--- a/src/core/lombok/experimental/core/descriptor/DescriptorType.java
+++ b/src/core/lombok/experimental/core/descriptor/DescriptorType.java
@@ -1,0 +1,7 @@
+package lombok.experimental.core.descriptor;
+
+public enum DescriptorType {
+	ANNOTATION, CLASS, CONSTRUCTOR, FIELD, GENERIC, GENERIC_TYPE, INTERFACE, METHOD_ARGUMENT, METHOD, METHOD_EXCEPTION, PACKAGE,
+	
+	;
+}

--- a/src/core/lombok/experimental/core/descriptor/FieldDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/FieldDescriptor.java
@@ -1,0 +1,36 @@
+package lombok.experimental.core.descriptor;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data @EqualsAndHashCode(callSuper = true) public class FieldDescriptor extends MemberDescriptor {
+	private Descriptor type; // field type
+	private String name;
+	
+	private Field reference;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.FIELD;
+	}
+	
+	@Override public MemberType getMemberType() {
+		return MemberType.FIELD;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/descriptor/GenericDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/GenericDescriptor.java
@@ -1,0 +1,39 @@
+package lombok.experimental.core.descriptor;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+// <T, X extends Object & Comparable<T>>
+// or
+// ? super Object
+@Data public class GenericDescriptor implements Descriptor {
+	private String name;
+	private boolean wildcard; // when defined as ?
+	
+	// when wildcard: null or size = 0
+	// when NOT wildcard: size > = 0
+	private List<GenericDescriptor> extendsOf;
+	
+	// when wildcard: if wildcard is li
+	// when NOT wildcard: null
+	private GenericDescriptor superOf; //
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.GENERIC;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/descriptor/GenericTypeDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/GenericTypeDescriptor.java
@@ -1,0 +1,31 @@
+package lombok.experimental.core.descriptor;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data @EqualsAndHashCode public class GenericTypeDescriptor implements Descriptor {
+	private GenericDescriptor generic;
+	private Type genericType;
+	private Class<?> type;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.GENERIC_TYPE;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/descriptor/InterfaceDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/InterfaceDescriptor.java
@@ -1,0 +1,37 @@
+package lombok.experimental.core.descriptor;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data @EqualsAndHashCode(callSuper = true) public class InterfaceDescriptor extends MemberDescriptor implements Descriptor {
+	private InterfaceDescriptor[] extended; // extends
+	private MemberDescriptor[] members;
+	private PackageDescriptor packaged;
+	private String name;
+	
+	private Class<?> reference;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.INTERFACE;
+	}
+	
+	@Override public MemberType getMemberType() {
+		return MemberType.INTERFACE;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/descriptor/MemberDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/MemberDescriptor.java
@@ -1,0 +1,17 @@
+package lombok.experimental.core.descriptor;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data public abstract class MemberDescriptor implements Descriptor {
+	private List<AnnotationDescriptor> annotations;
+	// TODO: ^^ move to children (generics are not needed for annotations)
+	private GenericDescriptor[] generics;
+	private List<Modifier> modifiers;
+	
+	// when this class is defined inside other class
+	private MemberDescriptor memberOf;
+	
+	public abstract MemberType getMemberType();
+}

--- a/src/core/lombok/experimental/core/descriptor/MemberType.java
+++ b/src/core/lombok/experimental/core/descriptor/MemberType.java
@@ -1,0 +1,7 @@
+package lombok.experimental.core.descriptor;
+
+public enum MemberType {
+	ANNOTATION, CLASS, CONSTRUCTOR, FIELD, INTERFACE, METHOD,
+	
+	;
+}

--- a/src/core/lombok/experimental/core/descriptor/MethodArgumentDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/MethodArgumentDescriptor.java
@@ -1,0 +1,31 @@
+package lombok.experimental.core.descriptor;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data public class MethodArgumentDescriptor implements Descriptor {
+	private AnnotationDescriptor[] annotations;
+	private GenericDescriptor generics;
+	private MethodDescriptor method;
+	private Modifier[] modifiers;
+	private String name;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.METHOD_ARGUMENT;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/descriptor/MethodDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/MethodDescriptor.java
@@ -1,0 +1,40 @@
+package lombok.experimental.core.descriptor;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Function;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data @EqualsAndHashCode(callSuper = true) public class MethodDescriptor extends MemberDescriptor {
+	private MethodExceptionDescriptor[] exceptions;
+	private MethodArgumentDescriptor[] arguments;
+	private Function<Object[], Object> handler;
+	private GenericDescriptor returnType;
+	// TODO: ^^ define separate descriptor to define return type
+	
+	private Method reference;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.METHOD;
+	}
+	
+	@Override public MemberType getMemberType() {
+		return MemberType.METHOD;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/descriptor/MethodExceptionDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/MethodExceptionDescriptor.java
@@ -1,0 +1,8 @@
+package lombok.experimental.core.descriptor;
+
+import lombok.Data;
+
+@Data public class MethodExceptionDescriptor {
+	private MethodDescriptor method;
+	private Class<?> reference;
+}

--- a/src/core/lombok/experimental/core/descriptor/Modifier.java
+++ b/src/core/lombok/experimental/core/descriptor/Modifier.java
@@ -1,0 +1,14 @@
+package lombok.experimental.core.descriptor;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum Modifier {
+	PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, SYNCHRONIZED, VOLATILE, TRANSIENT, NATIVE, INTERFACE, ABSTRACT, STRICT,
+	
+	;
+	
+	public static List<Modifier> all() {
+		return Arrays.asList(values());
+	};
+}

--- a/src/core/lombok/experimental/core/descriptor/PackageDescriptor.java
+++ b/src/core/lombok/experimental/core/descriptor/PackageDescriptor.java
@@ -1,0 +1,28 @@
+package lombok.experimental.core.descriptor;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+
+@Data public class PackageDescriptor implements Descriptor {
+	private String name;
+	private String full;
+	
+	@Override public List<Message> add(LombokCompiler compiler, boolean generate) {
+		return compiler.add(this, generate);
+	}
+	
+	@Override public DescriptorType getDescriptorType() {
+		return DescriptorType.PACKAGE;
+	}
+	
+	@Override public List<Message> modify(LombokCompiler compiler, boolean generate) {
+		return compiler.modify(this, generate);
+	}
+	
+	@Override public List<Message> remove(LombokCompiler compiler, boolean generate) {
+		return compiler.remove(this, generate);
+	}
+}

--- a/src/core/lombok/experimental/core/eclipse/EclipseLombokCompiler.java
+++ b/src/core/lombok/experimental/core/eclipse/EclipseLombokCompiler.java
@@ -1,0 +1,186 @@
+package lombok.experimental.core.eclipse;
+
+import java.util.List;
+
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+import lombok.experimental.core.descriptor.AnnotationDescriptor;
+import lombok.experimental.core.descriptor.ClassDescriptor;
+import lombok.experimental.core.descriptor.ConstructorDescriptor;
+import lombok.experimental.core.descriptor.FieldDescriptor;
+import lombok.experimental.core.descriptor.GenericDescriptor;
+import lombok.experimental.core.descriptor.GenericTypeDescriptor;
+import lombok.experimental.core.descriptor.InterfaceDescriptor;
+import lombok.experimental.core.descriptor.MethodArgumentDescriptor;
+import lombok.experimental.core.descriptor.MethodDescriptor;
+import lombok.experimental.core.descriptor.MethodExceptionDescriptor;
+import lombok.experimental.core.descriptor.PackageDescriptor;
+
+public class EclipseLombokCompiler implements LombokCompiler {
+	
+	@Override public List<Message> add(AnnotationDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(ClassDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(ConstructorDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(FieldDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(GenericDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(GenericTypeDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(InterfaceDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(MethodArgumentDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(MethodDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(MethodExceptionDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> add(PackageDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	@Override public List<Message> modify(AnnotationDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(ClassDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(ConstructorDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(FieldDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(GenericDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(GenericTypeDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(InterfaceDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(MethodArgumentDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(MethodDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(MethodExceptionDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> modify(PackageDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	@Override public List<Message> remove(AnnotationDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(ClassDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(ConstructorDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(FieldDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(GenericDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(GenericTypeDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(InterfaceDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(MethodArgumentDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(MethodDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(MethodExceptionDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	@Override public List<Message> remove(PackageDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+}

--- a/src/core/lombok/experimental/core/impl/LombokDescriptorFactoryImpl.java
+++ b/src/core/lombok/experimental/core/impl/LombokDescriptorFactoryImpl.java
@@ -1,0 +1,15 @@
+package lombok.experimental.core.impl;
+
+import lombok.experimental.core.LombokDescriptorFactory;
+import lombok.experimental.core.descriptor.ClassDescriptor;
+
+public abstract class LombokDescriptorFactoryImpl implements LombokDescriptorFactory {
+	
+	@Override public ClassDescriptor get(Class<?> type, Configuration configuration) {
+		if (type == null || configuration == null) {
+			return null;
+		}
+		
+		return null;
+	}
+}

--- a/src/core/lombok/experimental/core/impl/LombokFactoryImpl.java
+++ b/src/core/lombok/experimental/core/impl/LombokFactoryImpl.java
@@ -1,0 +1,232 @@
+package lombok.experimental.core.impl;
+
+import java.awt.TrayIcon.MessageType;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import jdk.nashorn.internal.objects.annotations.Setter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokDescriptorFactory;
+import lombok.experimental.core.LombokDescriptorFactory.Configuration;
+import lombok.experimental.core.LombokDescriptorFactory.Configuration.ConfigurationBuilder;
+import lombok.experimental.core.LombokFactory;
+import lombok.experimental.core.LombokPriorityFactory;
+import lombok.experimental.core.descriptor.AnnotationDescriptor;
+import lombok.experimental.core.descriptor.ClassDescriptor;
+import lombok.experimental.core.descriptor.Descriptor;
+import lombok.experimental.core.descriptor.MemberType;
+
+@RequiredArgsConstructor public class LombokFactoryImpl implements LombokFactory {
+	
+	/**
+	 * Default configuration to retrieve annotations only, is needed to pick up
+	 * lombok annotations (for now at the top level only).
+	 */
+	public static final Configuration ANNOTATIONS_ONLY = Configuration.builder().memberType(MemberType.ANNOTATION).build();
+	
+	private final LombokDescriptorFactory descriptorFactory;
+	private final LombokPriorityFactory priorityProvider;
+	private final LombokCompiler compiler;
+	
+	/**
+	 * Generate code for all descriptors
+	 * 
+	 * @param descriptors
+	 * @param action
+	 * @param generate
+	 * @return
+	 */
+	private List<Message> applyChanges(List<Descriptor> descriptors, Action action, boolean generate) {
+		// TODO: at this point i'm pretty sure we should not use lists
+		// most likely it should be tree of required modifications
+		// Because adding method arguments, exceptions make no sense without
+		// adding methods, but its OK even for POC.
+		// Also there is a way to sort it out:
+		// method arguments keep references to method descriptors, which:
+		// have references to all its children so they may initiate generation
+		// for the methods (with all arguments, exceptions) if it is needed.
+		for (Descriptor descriptor : descriptors) {
+			action.apply(compiler, descriptor, generate);
+		}
+		
+		// TODO: it should return real messages
+		return Collections.emptyList();
+	}
+	
+	/**
+	 * Collect changes to apply for particular lombok annotation
+	 * 
+	 * @param descriptor
+	 * @param itemsToRemove
+	 * @param itemsToModify
+	 * @param itemsToAdd
+	 */
+	private void collectChanges(AnnotationDescriptor descriptor, List<Descriptor> itemsToRemove, List<Descriptor> itemsToModify, List<Descriptor> itemsToAdd) {
+		if (descriptor.hasAnnotation(Setter.class)) {
+			// TODO: collect changes for setter here or delegate to other class
+			// TODO: this code supposed to add items to the end of the list to
+			// preserve order and avoid errors
+			// (like creating method to access field which has not been
+			// generated yet)
+		}
+	}
+	
+	/**
+	 * Collect changes to apply for all lombok annotations
+	 * 
+	 * @param lombokAnnotations
+	 * @param itemsToRemove
+	 * @param itemsToModify
+	 * @param itemsToAdd
+	 */
+	private void collectChanges(List<AnnotationDescriptor> lombokAnnotations, List<Descriptor> itemsToRemove, List<Descriptor> itemsToModify, List<Descriptor> itemsToAdd) {
+		for (AnnotationDescriptor annotation : lombokAnnotations) {
+			flagUsage(annotation);
+			collectChanges(annotation, itemsToRemove, itemsToModify, itemsToAdd);
+		}
+	}
+	
+	/**
+	 * Creates configuration to extract descriptions from the type. Descriptors
+	 * for lombok annotations are requried to change its behavior. Like for
+	 * super builder is is necessary to dive into parents, etc.
+	 * 
+	 * @param type
+	 * @param annotations
+	 * @return
+	 */
+	private Configuration createConfiguration(Class<?> type, List<AnnotationDescriptor> annotations) {
+		return Configuration.builder().memberType(MemberType.CLASS).memberType(MemberType.FIELD).memberType(MemberType.METHOD).members(createMemberConfiguration(type, annotations)).build();
+	}
+	
+	private Configuration createMemberConfiguration(Class<?> type, List<AnnotationDescriptor> annotations) {
+		ConfigurationBuilder<?, ?> builder = Configuration.builder();
+		if (hasAnnotation(annotations, Setter.class)) {
+			builder.memberType(MemberType.ANNOTATION).memberType(MemberType.METHOD).memberType(MemberType.FIELD);
+		}
+		return builder.build();
+	}
+	
+	private List<AnnotationDescriptor> findLombokAnnotations(Class<?> type) {
+		ClassDescriptor classDescriptor = descriptorFactory.get(type, ANNOTATIONS_ONLY);
+		List<AnnotationDescriptor> lombokAnnotations = classDescriptor.getAnnotations();
+		List<AnnotationDescriptor> annotations = classDescriptor.getAnnotations();
+		for (AnnotationDescriptor descriptor : annotations) {
+			if (descriptor.isLombok()) {
+				lombokAnnotations.add(descriptor);
+			}
+		}
+		return lombokAnnotations;
+	}
+	
+	private void flagUsage(AnnotationDescriptor annotation) {
+		// TODO flag lombok annotation is used
+		// TODO: consider delegating to separate class
+	}
+	
+	@Override public List<Message> generate(Class<?> type, boolean generate) {
+		// extracting lombok annotation descriptors (they are needed to extract
+		// the rest)
+		List<AnnotationDescriptor> lombokAnnotations = sortByPriority(findLombokAnnotations(type));
+		// TODO: ^^ instead of sorting lombok annotations here, we may consider
+		// sorting the whole tree
+		// using different priority provider for different IDE's will allow
+		// to modify generation order and thus sort fields/methods according to
+		// IDE preferences.
+		
+		// extract descriptor tree
+		Configuration configuration = createConfiguration(type, lombokAnnotations);
+		ClassDescriptor classDescriptor = descriptorFactory.get(type, configuration);
+		
+		// perform initial validation
+		List<Message> messages = validateDescriptor(classDescriptor, lombokAnnotations);
+		if (hasMessageType(messages, MessageType.ERROR)) {
+			return messages;
+		}
+		
+		// this part supposed to collect all changes required to apply
+		// this code just to show the idea
+		// better if it would return list of all required modifications
+		// event better if it would return some modification tree object
+		// which will contain references to all items which should be
+		// removed/updated/deleted
+		List<Descriptor> itemsToRemove = new LinkedList<Descriptor>();
+		List<Descriptor> itemsToModify = new LinkedList<Descriptor>();
+		List<Descriptor> itemsToAdd = new LinkedList<Descriptor>();
+		collectChanges(lombokAnnotations, itemsToRemove, itemsToModify, itemsToAdd);
+		
+		// apply all changes
+		List<Message> removeMessages = applyChanges(itemsToRemove, Action.REMOVE, generate);
+		messages.addAll(removeMessages);
+		if (hasMessageType(removeMessages, MessageType.ERROR)) {
+			return messages;
+		}
+		
+		List<Message> modifyMessages = applyChanges(itemsToModify, Action.MODIFY, generate);
+		messages.addAll(modifyMessages);
+		if (hasMessageType(modifyMessages, MessageType.ERROR)) {
+			return messages;
+		}
+		
+		List<Message> addMessages = applyChanges(itemsToAdd, Action.ADD, generate);
+		messages.addAll(addMessages);
+		if (hasMessageType(addMessages, MessageType.ERROR)) {
+			return messages;
+		}
+		
+		return messages;
+	}
+	
+	private boolean hasAnnotation(List<AnnotationDescriptor> annotations, Class<?> annotationType) {
+		for (AnnotationDescriptor descriptor : annotations) {
+			if (descriptor.hasAnnotation(annotationType)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
+	 * Check if there is a message with type
+	 * 
+	 * @param messages
+	 * @param error
+	 * @return
+	 */
+	private boolean hasMessageType(List<Message> messages, MessageType messageType) {
+		for (Message message : messages) {
+			if (message.hasType(messageType)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/**
+	 * This way we may ensure all annotations will be handled in correct
+	 * priority. Also it might help to simplify code generation or validation.
+	 * 
+	 * @param lombokAnnotations
+	 * @return sorted list
+	 */
+	private List<AnnotationDescriptor> sortByPriority(List<AnnotationDescriptor> lombokAnnotations) {
+		Collections.sort(lombokAnnotations, priorityProvider);
+		return lombokAnnotations;
+	}
+	
+	/**
+	 * This is needed to collect any info/warns/errors prior to any code
+	 * generation
+	 * 
+	 * @param classDescriptor
+	 * @param lombokAnnotations
+	 * @return
+	 */
+	private List<Message> validateDescriptor(ClassDescriptor descriptor, List<AnnotationDescriptor> lombokAnnotations) {
+		// TODO: implement intial validation
+		return Collections.emptyList();
+	}
+	
+}

--- a/src/core/lombok/experimental/core/javac/JavacLombokCompiler.java
+++ b/src/core/lombok/experimental/core/javac/JavacLombokCompiler.java
@@ -1,0 +1,384 @@
+package lombok.experimental.core.javac;
+
+import java.util.List;
+
+import lombok.experimental.core.LombokCompiler;
+import lombok.experimental.core.LombokFactory.Message;
+import lombok.experimental.core.descriptor.AnnotationDescriptor;
+import lombok.experimental.core.descriptor.ClassDescriptor;
+import lombok.experimental.core.descriptor.ConstructorDescriptor;
+import lombok.experimental.core.descriptor.FieldDescriptor;
+import lombok.experimental.core.descriptor.GenericDescriptor;
+import lombok.experimental.core.descriptor.GenericTypeDescriptor;
+import lombok.experimental.core.descriptor.InterfaceDescriptor;
+import lombok.experimental.core.descriptor.MethodArgumentDescriptor;
+import lombok.experimental.core.descriptor.MethodDescriptor;
+import lombok.experimental.core.descriptor.MethodExceptionDescriptor;
+import lombok.experimental.core.descriptor.PackageDescriptor;
+
+public class JavacLombokCompiler implements LombokCompiler {
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.AnnotationDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(AnnotationDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.ClassDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(ClassDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.ConstructorDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(ConstructorDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.FieldDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(FieldDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.GenericDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(GenericDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.GenericTypeDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(GenericTypeDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.InterfaceDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(InterfaceDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.MethodArgumentDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(MethodArgumentDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.MethodDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(MethodDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.MethodExceptionDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(MethodExceptionDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#add(lombok.experimental.core.descriptor.PackageDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> add(PackageDescriptor descriptor, boolean generate) {
+		// TODO implement add
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.AnnotationDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(AnnotationDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.ClassDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(ClassDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.ConstructorDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(ConstructorDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.FieldDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(FieldDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.GenericDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(GenericDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.GenericTypeDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(GenericTypeDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.InterfaceDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(InterfaceDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.MethodArgumentDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(MethodArgumentDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.MethodDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(MethodDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.MethodExceptionDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(MethodExceptionDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#modify(lombok.experimental.core.descriptor.PackageDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> modify(PackageDescriptor descriptor, boolean generate) {
+		// TODO implement modify
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.AnnotationDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(AnnotationDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.ClassDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(ClassDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.ConstructorDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(ConstructorDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.FieldDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(FieldDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.GenericDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(GenericDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.GenericTypeDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(GenericTypeDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.InterfaceDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(InterfaceDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.MethodArgumentDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(MethodArgumentDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.MethodDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(MethodDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.MethodExceptionDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(MethodExceptionDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @see lombok.experimental.core.LombokCompiler#remove(lombok.experimental.core.descriptor.PackageDescriptor,
+	 *      boolean)
+	 */
+	@Override public List<Message> remove(PackageDescriptor descriptor, boolean generate) {
+		// TODO implement remove
+		return null;
+	}
+	
+}


### PR DESCRIPTION
Previously:
- single feature = single handling class - it was good idea but features by design supposed to interact between itself so they any way aware of other ones
- adding new feature = adding new handler class and duplicating code, was not able to found a way to re-use high-level code, neither low level (compiler) code

With new structure:
- features aware of other features
- features rely on other features
- features supposed to rely on other features
- features supposed to re-use high level code
- features to re-use low-level code
- high level code and low level code reside on different abstraction levels
- features can be tested and introduced disregarding the compiler support
- compilers can be introduced and maintained disregarding the feature support

Issues:
- most likely place where source code was added is absolutely incorrect
- code is still very rough POC
- there are no features which rely on new code structure
- there is no POC code for compilers
- POC is not completed
- POC has tightly coupled with `java.lang.reflect` (should it?)

TODO's:
- sort out what is the proper way to translate lombok feauture (annotation) into "settings" object which will describe in intermediate terms what compiler should to do. Right now this is done via list of actions to be applied. Not sure this is good idea. At the moment it highlighted in the code with a lot of TODO's
- sort out what is the right place to put new code
- add java compiler support
- add eclipse compiler support
- migrate any existing feature to new code structure
- add tests for features
- add tests for compilers
- existing code should be reviewed for existing features, all features should be implemented via new POC